### PR TITLE
Builders force cheap defaults

### DIFF
--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -1681,6 +1681,7 @@ Pros:
  
 Cons:
  
+ - forces cheap defaults, e.g. `Supplier<ExpensiveResource>` rather than `ExpensiveResource` 
  - a bit more code to write
 
 References:


### PR DESCRIPTION
Multiple constructors don't allocate expensive fields unless you want to use them.
For builders, you need to initialize the defaults, even if you overwrite them.
It's not too big of a deal, because [constructors shouldn't allocate expensive resources anyway][constructor-doing-work].

[constructor-doing-work]: http://misko.hevery.com/code-reviewers-guide/flaw-constructor-does-real-work/